### PR TITLE
feat: scaffold Next.js frontend workspace

### DIFF
--- a/sillage-frontend/.env.example
+++ b/sillage-frontend/.env.example
@@ -1,0 +1,2 @@
+# URL base de la API expuesta por el backend de FastAPI
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api/v1

--- a/sillage-frontend/.eslintrc.json
+++ b/sillage-frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/sillage-frontend/.gitignore
+++ b/sillage-frontend/.gitignore
@@ -1,0 +1,23 @@
+# dependencies
+node_modules
+
+# next.js build output
+.next
+out
+
+# env files
+.env.local
+.env.*
+!.env.example
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# editor directories and files
+.DS_Store
+.vscode/*
+!.vscode/extensions.json
+.idea

--- a/sillage-frontend/.vscode/extensions.json
+++ b/sillage-frontend/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss"
+  ]
+}

--- a/sillage-frontend/README.md
+++ b/sillage-frontend/README.md
@@ -1,0 +1,35 @@
+# Sillage Frontend
+
+Base inicial para el nuevo frontend de Sillage utilizando Next.js 14, TypeScript, Tailwind CSS y TanStack Query.
+
+## Requisitos
+
+- Node.js 18.17 o superior
+- npm 9 o superior (o el gestor de paquetes de tu preferencia)
+
+## Scripts disponibles
+
+- `npm run dev`: inicia el servidor de desarrollo en `http://localhost:3000`.
+- `npm run build`: genera la versión optimizada para producción.
+- `npm run start`: ejecuta la compilación de producción.
+- `npm run lint`: ejecuta ESLint con la configuración de Next.js.
+- `npm run typecheck`: verifica los tipos con TypeScript sin emitir archivos.
+
+## Configuración
+
+1. Copia `.env.example` a `.env.local` y ajusta las variables necesarias.
+2. Instala dependencias con `npm install`.
+3. Ejecuta `npm run dev` para iniciar el desarrollo.
+
+## Integración con el backend
+
+El helper `apiFetch` en `src/lib/api.ts` centraliza las peticiones a la API FastAPI (`http://localhost:8000/api/v1` por defecto).
+Puedes ajustar la variable de entorno `NEXT_PUBLIC_API_BASE_URL` para apuntar a otros entornos.
+
+## Próximos pasos sugeridos
+
+- Crear el diseño de páginas principales (onboarding, dashboard, colección de perfumes, recomendaciones).
+- Implementar autenticación basada en JWT almacenados de forma segura (cookies httpOnly o secure storage).
+- Sincronizar el sistema de diseño emocional definido en `Documentation/sillage_style_guide.md`.
+- Configurar Storybook o Ladle para documentar componentes reutilizables.
+- Preparar la base compartida de hooks y utilidades para React Native / Expo.

--- a/sillage-frontend/app/globals.css
+++ b/sillage-frontend/app/globals.css
@@ -1,0 +1,61 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 210 40% 98%;
+  --foreground: 222 47% 11%;
+  --primary: 259 94% 51%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 183 47% 63%;
+  --secondary-foreground: 222 47% 11%;
+  --accent: 22 90% 58%;
+  --accent-foreground: 210 40% 98%;
+  --muted: 215 16% 82%;
+  --muted-foreground: 222 47% 11%;
+  --border: 217 16% 84%;
+  --input: 217 16% 84%;
+  --ring: 259 94% 51%;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: 222 47% 11%;
+    --foreground: 210 40% 98%;
+    --primary: 259 94% 71%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 183 47% 43%;
+    --secondary-foreground: 210 40% 98%;
+    --accent: 22 90% 68%;
+    --accent-foreground: 222 47% 11%;
+    --muted: 223 47% 20%;
+    --muted-foreground: 210 40% 98%;
+    --border: 217 33% 32%;
+    --input: 217 33% 32%;
+    --ring: 259 94% 71%;
+    color-scheme: dark;
+  }
+}
+
+html {
+  font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+}

--- a/sillage-frontend/app/layout.tsx
+++ b/sillage-frontend/app/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { Inter, Playfair_Display } from "next/font/google";
+import "./globals.css";
+import { Providers } from "./providers";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans"
+});
+
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  variable: "--font-serif"
+});
+
+export const metadata: Metadata = {
+  title: "Sillage",
+  description: "Asistente personal para tu colección de perfumes"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es" className={`${inter.variable} ${playfair.variable}`}>
+      <body>
+        <Providers>
+          <main>{children}</main>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/sillage-frontend/app/page.tsx
+++ b/sillage-frontend/app/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+
+const resources = [
+  {
+    href: "https://beta.nextjs.org/docs",
+    title: "Guía Next.js",
+    description: "Documentación oficial para construir la nueva experiencia web de Sillage."
+  },
+  {
+    href: "https://tanstack.com/query/latest",
+    title: "TanStack Query",
+    description: "Maneja datos asincrónicos y caché alineada con la API de FastAPI."
+  },
+  {
+    href: "https://tailwindcss.com/docs",
+    title: "Tailwind CSS",
+    description: "Implementa el sistema de diseño emocional con utilidades consistentes."
+  }
+];
+
+export default function Home() {
+  return (
+    <section className="w-full max-w-4xl space-y-12 animate-fade-in">
+      <header className="space-y-4 text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-secondary-foreground/80">
+          Bienvenido al nuevo frontend de Sillage
+        </p>
+        <h1 className="text-4xl font-serif font-semibold text-primary sm:text-5xl">
+          El punto de partida para una experiencia sensorial
+        </h1>
+        <p className="mx-auto max-w-2xl text-base text-muted-foreground">
+          Esta base con Next.js, TypeScript, Tailwind CSS y TanStack Query está lista para
+          integrarse con el backend FastAPI. Añade páginas, componentes y lógica compartida
+          para llegar a web, iOS y Android desde una sola plataforma React.
+        </p>
+      </header>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        {resources.map((resource) => (
+          <Link
+            key={resource.href}
+            href={resource.href}
+            className="group rounded-2xl border border-border/60 bg-background/60 p-6 transition hover:border-primary/70 hover:shadow-lg"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <h2 className="text-xl font-semibold text-foreground group-hover:text-primary">
+              {resource.title}
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">{resource.description}</p>
+            <span className="mt-4 inline-flex items-center text-sm font-medium text-primary group-hover:translate-x-1 transition-transform">
+              Abrir recurso →
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/sillage-frontend/app/providers.tsx
+++ b/sillage-frontend/app/providers.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
+    </QueryClientProvider>
+  );
+}

--- a/sillage-frontend/next-env.d.ts
+++ b/sillage-frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/sillage-frontend/next.config.ts
+++ b/sillage-frontend/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/sillage-frontend/package.json
+++ b/sillage-frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "sillage-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.37.1",
+    "@tanstack/react-query-devtools": "^5.37.1",
+    "clsx": "^2.1.0",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.79",
+    "@types/react-dom": "18.2.25",
+    "autoprefixer": "10.4.18",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/sillage-frontend/postcss.config.js
+++ b/sillage-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/sillage-frontend/src/lib/api.ts
+++ b/sillage-frontend/src/lib/api.ts
@@ -1,0 +1,29 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+export async function apiFetch<TResponse>(input: RequestInfo, init?: RequestInit): Promise<TResponse> {
+  const request = new Request(input instanceof Request ? input : `${API_BASE_URL}${input}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {})
+    },
+    ...init
+  });
+
+  const response = await fetch(request);
+
+  if (!response.ok) {
+    const errorBody = await safeJson(response);
+    const error = new Error(errorBody?.detail ?? response.statusText);
+    throw error;
+  }
+
+  return (await safeJson(response)) as TResponse;
+}
+
+async function safeJson(response: Response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    return null;
+  }
+}

--- a/sillage-frontend/tailwind.config.ts
+++ b/sillage-frontend/tailwind.config.ts
@@ -1,0 +1,52 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))"
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        serif: ["var(--font-serif)", "Georgia", "serif"]
+      },
+      keyframes: {
+        "fade-in": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" }
+        }
+      },
+      animation: {
+        "fade-in": "fade-in 300ms ease-out"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/sillage-frontend/tsconfig.json
+++ b/sillage-frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/app/*": ["./app/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/lib/*": ["./src/lib/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 + TypeScript workspace for the Sillage frontend with Tailwind CSS and TanStack Query
- add global styles, layout providers, and a placeholder landing page wired to the new design tokens
- document environment variables, npm scripts, and recommended tooling for the new client app

## Testing
- npm install *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddca674da48330b0d589d9b60a07ec