### PR TITLE
Protect user-created perfumes

### DIFF
--- a/sillage-backend/app/models/perfume.py
+++ b/sillage-backend/app/models/perfume.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey, Table
+from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey, Table, Boolean
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -17,15 +17,18 @@ perfume_collection = Table(
 
 class Perfume(Base):
     __tablename__ = "perfumes"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     nombre = Column(String(200), nullable=False, index=True)
     marca = Column(String(100), nullable=False, index=True)
     perfumista = Column(String(100), nullable=True)
-    
+
     # Datos JSON para notas y acordes
     notas = Column(JSON, default=list)
     acordes = Column(JSON, default=list)
+
+    is_private = Column(Boolean, nullable=False, default=False)
+    created_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/sillage-backend/app/schemas/perfume.py
+++ b/sillage-backend/app/schemas/perfume.py
@@ -27,7 +27,9 @@ class PerfumeInDB(PerfumeBase):
     id: int
     created_at: datetime
     updated_at: Optional[datetime]
-    
+    is_private: bool = False
+    created_by: Optional[int] = None
+
     class Config:
         from_attributes = True
 


### PR DESCRIPTION
## Summary
- add privacy metadata to perfumes to track ownership
- ensure searches and collection operations hide private perfumes from other users while linking new ones to their creator
- cover private perfume behaviour with tests that verify visibility per user

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e096d648b4833092ee0da453d3e25e