### PR TITLE
Prevent removed perfumes from being recommended

### DIFF
--- a/sillage-backend/app/api/v1/endpoints/recommendations.py
+++ b/sillage-backend/app/api/v1/endpoints/recommendations.py
@@ -26,7 +26,8 @@ async def create_recommendation(
         perfume_collection,
         and_(
             perfume_collection.c.perfume_id == Perfume.id,
-            perfume_collection.c.user_id == current_user.id
+            perfume_collection.c.user_id == current_user.id,
+            perfume_collection.c.removed_at.is_(None)
         )
     )
     


### PR DESCRIPTION
## Summary
- ensure the recommendations endpoint filters out perfumes removed from a collection
- add a test that verifies a soft-deleted perfume no longer satisfies recommendation prerequisites

## Testing
- PYTHONPATH=sillage-backend pytest sillage-backend/tests/test_perfume_collection.py::test_create_recommendation_returns_400_when_no_active_perfumes -q

------
https://chatgpt.com/codex/tasks/task_e_68e09e6cf674833090e5935ce0d8e356